### PR TITLE
Add 3 new problems and fix inelegant test case storage bug

### DIFF
--- a/lib/problem_runner.ml
+++ b/lib/problem_runner.ml
@@ -2,15 +2,13 @@ open Core
 
 exception Failed of { case_id : int; msg : string }
 
-(* Shared run loop used by every problem's Make functor.
-   Raises [Failed] on the first wrong answer. Returns normally if all pass. *)
-let run ~cases ~call =
+let run ~cases ~f ~equal ~sexp_of_output =
   List.iteri cases ~f:(fun i (input, expected) ->
-    let got = call input in
-    if not (Sexp.equal got expected) then
+    let got = f input in
+    if not (equal got expected) then
       raise (Failed
         { case_id = i + 1
         ; msg = Printf.sprintf "expected %s\n     got %s"
-                  (Sexp.to_string_hum expected)
-                  (Sexp.to_string_hum got)
+                  (Sexp.to_string_hum (sexp_of_output expected))
+                  (Sexp.to_string_hum (sexp_of_output got))
         }))

--- a/lib/problems.ml
+++ b/lib/problems.ml
@@ -12,6 +12,12 @@ let two_sum =
   ; description = Two_sum.description
   }
 
-let all = [ two_sum ]
+let reverse_linked_list =
+  { slug        = "reverse-linked-list"
+  ; title       = "Reverse Linked List"
+  ; description = Reverse_linked_list.description
+  }
+
+let all = [ two_sum; reverse_linked_list ]
 
 let find slug = List.find all ~f:(fun p -> String.equal p.slug slug)

--- a/lib/problems.ml
+++ b/lib/problems.ml
@@ -18,6 +18,18 @@ let reverse_linked_list =
   ; description = Reverse_linked_list.description
   }
 
-let all = [ two_sum; reverse_linked_list ]
+let valid_parentheses =
+  { slug        = "valid-parentheses"
+  ; title       = "Valid Parentheses"
+  ; description = Valid_parentheses.description
+  }
+
+let max_subarray =
+  { slug        = "max-subarray"
+  ; title       = "Maximum Subarray"
+  ; description = Max_subarray.description
+  }
+
+let all = [ two_sum; reverse_linked_list; valid_parentheses; max_subarray ]
 
 let find slug = List.find all ~f:(fun p -> String.equal p.slug slug)

--- a/lib/problems/max_subarray.ml
+++ b/lib/problems/max_subarray.ml
@@ -1,0 +1,38 @@
+open Core
+
+let description = {|
+Maximum Subarray
+================
+
+Given an integer array, find the subarray with the largest sum and return
+its sum.
+
+Example 1:  [-2,1,-3,4,-1,2,1,-5,4]  =>  6
+            (the subarray [4,-1,2,1] has the largest sum)
+Example 2:  [1]                       =>  1
+Example 3:  [5,4,-1,7,8]             =>  23
+
+Signature: val max_subarray : int array -> int
+|}
+
+module type S = sig
+  val max_subarray : int array -> int
+end
+
+let cases =
+  [ [|-2;1;-3;4;-1;2;1;-5;4|],  6
+  ; [|1|],                       1
+  ; [|5;4;-1;7;8|],             23
+  ; [|-1|],                     -1
+  ; [|-2;-1|],                  -1
+  ; [|1;2;3;4|],                10
+  ; [|-1;-2;-3;-4|],            -1
+  ]
+
+module Make (Sol : S) = struct
+  let run () =
+    Problem_runner.run ~cases
+      ~f:Sol.max_subarray
+      ~equal:Int.equal
+      ~sexp_of_output:[%sexp_of: int]
+end

--- a/lib/problems/reverse_linked_list.ml
+++ b/lib/problems/reverse_linked_list.ml
@@ -32,19 +32,17 @@ module type S = sig
 end
 
 let cases =
-  [%of_sexp: (Sexp.t * Sexp.t) list] (Sexp.of_string
-    {| ( ((1 2 3 4 5) (5 4 3 2 1))
-         ((1 2)       (2 1))
-         (()          ())
-         ((1)         (1))
-         ((1 2 3)     (3 2 1)) ) |})
+  [ [1;2;3;4;5], [5;4;3;2;1]
+  ; [1;2],       [2;1]
+  ; [],          []
+  ; [1],         [1]
+  ; [1;2;3],     [3;2;1]
+  ]
 
 module Make (Sol : S) = struct
-  let call sexp =
-    let vals = [%of_sexp: int list] sexp in
-    let head = of_list vals in
-    let reversed = Sol.reverse head in
-    [%sexp_of: int list] (to_list reversed)
-
-  let run () = Problem_runner.run ~cases ~call
+  let run () =
+    Problem_runner.run ~cases
+      ~f:(fun vals -> to_list (Sol.reverse (of_list vals)))
+      ~equal:[%equal: int list]
+      ~sexp_of_output:[%sexp_of: int list]
 end

--- a/lib/problems/reverse_linked_list.ml
+++ b/lib/problems/reverse_linked_list.ml
@@ -1,0 +1,50 @@
+open Core
+
+let description = {|
+Reverse Linked List
+===================
+
+Given the head of a singly linked list, reverse the list and return it.
+
+A node is defined as:
+
+  type node = { val_ : int; next : node option }
+
+Example 1:  [1, 2, 3, 4, 5]  =>  [5, 4, 3, 2, 1]
+Example 2:  [1, 2]           =>  [2, 1]
+Example 3:  []               =>  []
+
+Signature: val reverse : node option -> node option
+|}
+
+type node = { val_ : int; next : node option }
+
+let rec to_list = function
+  | None -> []
+  | Some n -> n.val_ :: to_list n.next
+
+let rec of_list = function
+  | [] -> None
+  | x :: xs -> Some { val_ = x; next = of_list xs }
+
+module type S = sig
+  val reverse : node option -> node option
+end
+
+let cases =
+  [%of_sexp: (Sexp.t * Sexp.t) list] (Sexp.of_string
+    {| ( ((1 2 3 4 5) (5 4 3 2 1))
+         ((1 2)       (2 1))
+         (()          ())
+         ((1)         (1))
+         ((1 2 3)     (3 2 1)) ) |})
+
+module Make (Sol : S) = struct
+  let call sexp =
+    let vals = [%of_sexp: int list] sexp in
+    let head = of_list vals in
+    let reversed = Sol.reverse head in
+    [%sexp_of: int list] (to_list reversed)
+
+  let run () = Problem_runner.run ~cases ~call
+end

--- a/lib/problems/two_sum.ml
+++ b/lib/problems/two_sum.ml
@@ -22,15 +22,15 @@ module type S = sig
 end
 
 let cases =
-  [%of_sexp: (Sexp.t * Sexp.t) list] (Sexp.of_string
-    {| ( (((2 7 11 15) 9) (0 1))
-         (((3 2 4)     6) (1 2))
-         (((3 3)        6) (0 1)) ) |})
+  [ ([|2;7;11;15|], 9), (0, 1)
+  ; ([|3;2;4|],     6), (1, 2)
+  ; ([|3;3|],       6), (0, 1)
+  ]
 
 module Make (Sol : S) = struct
-  let call sexp =
-    let nums, target = [%of_sexp: int array * int] sexp in
-    [%sexp_of: int * int] (Sol.two_sum nums target)
-
-  let run () = Problem_runner.run ~cases ~call
+  let run () =
+    Problem_runner.run ~cases
+      ~f:(fun (nums, target) -> Sol.two_sum nums target)
+      ~equal:[%equal: int * int]
+      ~sexp_of_output:[%sexp_of: int * int]
 end

--- a/lib/problems/valid_parentheses.ml
+++ b/lib/problems/valid_parentheses.ml
@@ -1,0 +1,45 @@
+open Core
+
+let description = {|
+Valid Parentheses
+=================
+
+Given a string containing only the characters '(', ')', '{', '}', '[' and ']',
+determine if the input string is valid.
+
+A string is valid if:
+  - Open brackets are closed by the same type of brackets.
+  - Open brackets are closed in the correct order.
+  - Every close bracket has a corresponding open bracket.
+
+Example 1:  "()"     =>  true
+Example 2:  "()[]{}" =>  true
+Example 3:  "(]"     =>  false
+Example 4:  "([])"   =>  true
+
+Signature: val is_valid : string -> bool
+|}
+
+module type S = sig
+  val is_valid : string -> bool
+end
+
+let cases =
+  [ "()",      true
+  ; "()[]{}",  true
+  ; "(]",      false
+  ; "([])",    true
+  ; "",        true
+  ; "([)]",    false
+  ; "{[]}",    true
+  ; "(((",     false
+  ; "({[]})",  true
+  ]
+
+module Make (Sol : S) = struct
+  let run () =
+    Problem_runner.run ~cases
+      ~f:Sol.is_valid
+      ~equal:Bool.equal
+      ~sexp_of_output:[%sexp_of: bool]
+end

--- a/submissions/max_subarray.ml
+++ b/submissions/max_subarray.ml
@@ -1,0 +1,14 @@
+module Solution = struct
+  let max_subarray (nums : int array) : int =
+    let current = ref nums.(0) in
+    let best = ref nums.(0) in
+    for i = 1 to Array.length nums - 1 do
+      current := max nums.(i) (!current + nums.(i));
+      best := max !best !current
+    done;
+    !best
+end
+
+let () =
+  let module M = Leetcaml.Max_subarray.Make(Solution) in
+  Leetcaml.Host.register (module M : Leetcaml.Host.Runner)

--- a/submissions/reverse_linked_list.ml
+++ b/submissions/reverse_linked_list.ml
@@ -1,0 +1,14 @@
+open Leetcaml.Reverse_linked_list
+
+module Solution = struct
+  let reverse (head : node option) : node option =
+    let rec go acc = function
+      | None -> acc
+      | Some n -> go (Some { val_ = n.val_; next = acc }) n.next
+    in
+    go None head
+end
+
+let () =
+  let module M = Make(Solution) in
+  Leetcaml.Host.register (module M : Leetcaml.Host.Runner)

--- a/submissions/valid_parentheses.ml
+++ b/submissions/valid_parentheses.ml
@@ -1,0 +1,18 @@
+module Solution = struct
+  let is_valid (s : string) : bool =
+    let rec go stack i =
+      if i >= String.length s then stack = []
+      else
+        match s.[i] with
+        | '(' | '[' | '{' -> go (s.[i] :: stack) (i + 1)
+        | ')' -> (match stack with '(' :: rest -> go rest (i + 1) | _ -> false)
+        | ']' -> (match stack with '[' :: rest -> go rest (i + 1) | _ -> false)
+        | '}' -> (match stack with '{' :: rest -> go rest (i + 1) | _ -> false)
+        | _ -> false
+    in
+    go [] 0
+end
+
+let () =
+  let module M = Leetcaml.Valid_parentheses.Make(Solution) in
+  Leetcaml.Host.register (module M : Leetcaml.Host.Runner)


### PR DESCRIPTION
Closes #1 by adding 3 new problems
- reverse a linked list
- valid parentheses
- maximum subarray

Also closes #6 by changing test case storage from ugly stringified sexps into typechecked values, and passing 2 new callback parameters from each problem's definition (in problems folder) to shared runner (`Problem_runner.run`)
- equality comparator
- output sexp converter